### PR TITLE
OSSM-2233: exposes all manifests with their content

### DIFF
--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -34,7 +34,7 @@ func GetManifestsByName() (map[string][]byte, error) {
 		name := entry.Name()
 		content, err := ReadManifest(name)
 		if err != nil {
-			return manifestsByName, err
+			return nil, err
 		}
 		manifestsByName[name] = content
 	}

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -1,0 +1,43 @@
+package manifests
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed *.yaml
+var res embed.FS
+
+// GetManifests returns a slice of the DirEntries embedded in this folder.
+func GetManifests() ([]fs.DirEntry, error) {
+	return res.ReadDir(".")
+}
+
+// ReadManifest reads embedded file content for the passed name.
+func ReadManifest(name string) ([]byte, error) {
+	return res.ReadFile(name)
+}
+
+// GetManifestsByName returns a map of all manifest names and their content.
+// It propagates error if it wasn't able to read the content.
+func GetManifestsByName() (map[string][]byte, error) {
+	entries, err := res.ReadDir(".")
+	if err != nil {
+		return nil, err
+	}
+
+	manifestsByName := make(map[string][]byte)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		content, err := ReadManifest(name)
+		if err != nil {
+			return manifestsByName, err
+		}
+		manifestsByName[name] = content
+	}
+
+	return manifestsByName, nil
+}

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -1,0 +1,47 @@
+package manifests_test
+
+import (
+	"bytes"
+	"fmt"
+	"maistra.io/api/manifests"
+	"testing"
+)
+
+func TestGettingManifestDirEntries(t *testing.T) {
+	manifests, err := manifests.GetManifests()
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error: %v", err))
+	}
+	if len(manifests) == 0 {
+		t.Fatalf("Expected to have non-zero amount of nested files")
+	}
+}
+
+func TestGettingManifestsByName(t *testing.T) {
+	manifestsByName, err := manifests.GetManifestsByName()
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error: %v", err))
+	}
+	if len(manifestsByName) == 0 {
+		t.Fatalf("Expected to have non-zero amount of nested files")
+	}
+}
+
+func TestLoadingManifestByName(t *testing.T) {
+	manifestsByName, err := manifests.GetManifestsByName()
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error: %v", err))
+	}
+	if len(manifestsByName) == 0 {
+		t.Fatalf("Expected to have non-zero amount of nested files")
+	}
+	smmYAML := "maistra.io_servicemeshmembers.yaml"
+
+	smmContent, err := manifests.ReadManifest(smmYAML)
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error: %v", err))
+	}
+	if bytes.Compare(manifestsByName[smmYAML], smmContent) != 0 {
+		t.Fatalf("Expected to have identical content")
+	}
+}

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -2,7 +2,6 @@ package manifests_test
 
 import (
 	"bytes"
-	"fmt"
 	"maistra.io/api/manifests"
 	"testing"
 )
@@ -10,7 +9,7 @@ import (
 func TestGettingManifestDirEntries(t *testing.T) {
 	manifests, err := manifests.GetManifests()
 	if err != nil {
-		panic(fmt.Sprintf("Unexpected error: %v", err))
+		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(manifests) == 0 {
 		t.Fatalf("Expected to have non-zero amount of nested files")
@@ -20,7 +19,7 @@ func TestGettingManifestDirEntries(t *testing.T) {
 func TestGettingManifestsByName(t *testing.T) {
 	manifestsByName, err := manifests.GetManifestsByName()
 	if err != nil {
-		panic(fmt.Sprintf("Unexpected error: %v", err))
+		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(manifestsByName) == 0 {
 		t.Fatalf("Expected to have non-zero amount of nested files")
@@ -30,7 +29,7 @@ func TestGettingManifestsByName(t *testing.T) {
 func TestLoadingManifestByName(t *testing.T) {
 	manifestsByName, err := manifests.GetManifestsByName()
 	if err != nil {
-		panic(fmt.Sprintf("Unexpected error: %v", err))
+		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(manifestsByName) == 0 {
 		t.Fatalf("Expected to have non-zero amount of nested files")
@@ -39,7 +38,7 @@ func TestLoadingManifestByName(t *testing.T) {
 
 	smmContent, err := manifests.ReadManifest(smmYAML)
 	if err != nil {
-		panic(fmt.Sprintf("Unexpected error: %v", err))
+		t.Errorf("Unexpected error: %v", err)
 	}
 	if bytes.Compare(manifestsByName[smmYAML], smmContent) != 0 {
 		t.Fatalf("Expected to have identical content")

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -1,13 +1,12 @@
-package manifests_test
+package manifests
 
 import (
 	"bytes"
-	"maistra.io/api/manifests"
 	"testing"
 )
 
 func TestGettingManifestDirEntries(t *testing.T) {
-	manifests, err := manifests.GetManifests()
+	manifests, err := GetManifests()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -17,7 +16,7 @@ func TestGettingManifestDirEntries(t *testing.T) {
 }
 
 func TestGettingManifestsByName(t *testing.T) {
-	manifestsByName, err := manifests.GetManifestsByName()
+	manifestsByName, err := GetManifestsByName()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -27,7 +26,7 @@ func TestGettingManifestsByName(t *testing.T) {
 }
 
 func TestLoadingManifestByName(t *testing.T) {
-	manifestsByName, err := manifests.GetManifestsByName()
+	manifestsByName, err := GetManifestsByName()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -36,7 +35,7 @@ func TestLoadingManifestByName(t *testing.T) {
 	}
 	smmYAML := "maistra.io_servicemeshmembers.yaml"
 
-	smmContent, err := manifests.ReadManifest(smmYAML)
+	smmContent, err := ReadManifest(smmYAML)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
Adds the ability to fetch `manifests/*.yaml` content directly from the code (using `//go:embed` directive), instead of relying on files being present in the `vendor/` directory. This way we don't need to rely on `vendor/` in our `maistra/istio` tests.

https://github.com/maistra/istio/blob/cccdbb9ed1089992171c81fb490320d8387f7704/tests/integration/servicemesh/maistra/maistra.go#L50

vs

https://github.com/maistra/istio/blob/a657495737bc1164b4908f8f86a47226c01c7f4d/tests/integration/servicemesh/maistra/maistra.go#L46

Plus happy-path tests.
